### PR TITLE
docs: add SRE cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,3 +533,4 @@ Contributions are always welcome!
 ## SRE Tools
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
+* [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers


### PR DESCRIPTION
This PR adds a link to my SRE cheat sheet. I was unsure about the paragraph/section for it. If you want it somewhere else, no worries, I can move it.